### PR TITLE
Fix cb fs.chmod and require modules

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
+/.git
 /node_modules
 /npm-debug.log

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# net-listen
+# net-listen2
 
 Node listen helper for net module helping with socket listening.
 
@@ -9,7 +9,7 @@ Node listen helper for net module helping with socket listening.
 
 # Installation
 
-	npm install net-listen --save
+	npm install net-listen2 --save
 	 
 	 
 # Usage

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Node listen helper for net module helping with socket listening.
 ## Getting started 
 
 	var http = require('http');
-	var netListen = require('net-listen');
+	var netListen = require('net-listen2');
 	
 	var server = http.createServer();
 	var path = 'path/to/socket.sock';

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-var fs = require('fs');
-var net = require('net');
+var fs = require('node:fs');
+var net = require('node:net');
 
 module.exports = {
 
@@ -27,7 +27,9 @@ module.exports = {
 		server.once('listening', function() {
 			if (config.path) {
 				// change socket permissions
-				fs.chmod(config.path, config.pathMode || 0777);
+				fs.chmod(config.path, config.pathMode || 0777,  () => {
+					console.log("\nFile " + config.path + " has now been edited.");
+				});
 			}
 			callback(null);
 		});


### PR DESCRIPTION
Fixed bug in use `fs.chmod()` and fix include node-modules for `fs` and `net`

### Bug:
```
Node.js v20.9.0
TypeError [ERR_INVALID_ARG_TYPE]: The "cb" argument must be of type function. Received undefined
    at makeCallback (node:fs:187:3)
    at Object.chmod (node:fs:1942:14)
    at Server.<anonymous> (/api/node_modules/net-listen/index.js:30:8)
    at Object.onceWrapper (node:events:628:28)
    at Server.emit (node:events:526:35)
    at emitListeningNT (node:net:1906:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:81:21) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```